### PR TITLE
[FIX] Possible fix for CI fail issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,13 @@ jobs:
           ${{ runner.os }}-gradle-
     
     - uses: actions/checkout@v3
+
+    # https://github.com/actions/setup-java
     - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'temurin'
+        distribution: 'zulu'
         cache: gradle
 
     - name: Grant execute permission for gradlew


### PR DESCRIPTION
https://github.com/hossain-khan/github-stats/actions/runs/3108652360/jobs/5038082757

```
> Task :testClasses

2 tests completed, 2 failed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.
> There were failing tests. See the report at: file:///home/runner/work/github-stats/github-stats/build/reports/tests/test/index.html

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 13s
> Task :test FAILED

ClientTest > given timeline response - parses timeline into timeline events() FAILED
    java.io.IOException at :-1
        Caused by: java.io.IOException at RealCall.kt:530

ClientTest > given empty timeline response - provides empty timeline events() FAILED
    java.io.IOException at :-1
        Caused by: java.io.IOException at RealCall.kt:530
11 actionable tasks: 9 executed, 2 up-to-date
Error: Process completed with exit code 1.
```