### PR TITLE
[FIX] Enable HTTP caching to avoid date limits

### DIFF
--- a/src/main/kotlin/dev/hossain/githubstats/BuildConfig.kt
+++ b/src/main/kotlin/dev/hossain/githubstats/BuildConfig.kt
@@ -21,5 +21,5 @@ object BuildConfig {
      * User-to-server requests are limited to 5,000 requests per hour and per authenticated user.
      * See https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
      */
-    const val API_REQUEST_DELAY_MS: Long = 20L
+    const val API_REQUEST_DELAY_MS: Long = 100L
 }

--- a/src/main/kotlin/dev/hossain/githubstats/io/Client.kt
+++ b/src/main/kotlin/dev/hossain/githubstats/io/Client.kt
@@ -12,7 +12,9 @@ import dev.hossain.githubstats.model.timeline.ReviewedEvent
 import dev.hossain.githubstats.model.timeline.TimelineEvent
 import dev.hossain.githubstats.model.timeline.UnknownEvent
 import dev.hossain.githubstats.service.GithubService
+import dev.hossain.githubstats.util.FileUtil.httpCacheDir
 import dev.hossain.githubstats.util.LocalProperties
+import okhttp3.Cache
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
@@ -67,6 +69,14 @@ object Client {
 
             chain.proceed(requestBuilder.build())
         }
+
+        // https://square.github.io/okhttp/features/caching/
+        builder.cache(
+            Cache(
+                directory = httpCacheDir(),
+                maxSize = 200L * 1024L * 1024L // 200 MiB
+            )
+        )
 
         return builder.build()
     }

--- a/src/main/kotlin/dev/hossain/githubstats/util/FileUtil.kt
+++ b/src/main/kotlin/dev/hossain/githubstats/util/FileUtil.kt
@@ -10,11 +10,27 @@ object FileUtil {
     private const val REPORTS_DIR_PREFIX = "REPORTS"
     private const val REPORT_FILE_PREFIX = "REPORT"
 
+    /**
+     * Creates reporting directory path with known prefix.
+     */
     private fun createReportDir(directoryName: String): File {
         val directory = File("$REPORTS_DIR_PREFIX-$directoryName")
         if (directory.exists().not() && directory.mkdir()) {
             if (BuildConfig.DEBUG) {
                 println("The reporting directory ${directory.path} created successfully.")
+            }
+        }
+        return directory
+    }
+
+    /**
+     * Provides HTTP cache directory path.
+     */
+    internal fun httpCacheDir(): File {
+        val directory = File("http-cache")
+        if (directory.exists().not() && directory.mkdir()) {
+            if (BuildConfig.DEBUG) {
+                println("The HTTP cache directory ${directory.path} created successfully.")
             }
         }
         return directory


### PR DESCRIPTION
Example usage and limit.
Hourly its 5K and 30 for search.
```
x-ratelimit-limit: 5000
x-ratelimit-remaining: 1509
x-ratelimit-reset: 1664937631
x-ratelimit-used: 3491
x-ratelimit-resource: core
```