### PR TITLE
[DOCS] Added some docs for date time extensions

### DIFF
--- a/src/main/kotlin/dev/hossain/time/DateTimeDiffer.kt
+++ b/src/main/kotlin/dev/hossain/time/DateTimeDiffer.kt
@@ -144,13 +144,57 @@ object DateTimeDiffer {
     }
 
     // region: Internal Extension Functions
+    /**
+     * Provides date-time set to 12:00 AM of the same time-time provided.
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Saturday 12 AM (Reset to 12:00 am)
+     *  - Current Date Time: Sunday 11 AM   --> Sunday 12 AM (Reset to 12:00 am)
+     *  - Current Date Time: Monday 2 PM    --> Monday 12 AM (Reset to 12:00 am)
+     */
     private fun ZonedDateTime.startOfDay() = this.with(TemporalsExtension.startOfDay())
+
+    /**
+     * Provides next working day for current date-time.
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Monday 11 AM (nex working day - excluding weekends)
+     *  - Current Date Time: Sunday 11 AM   --> Monday 11 AM (nex working day - excluding weekends)
+     *  - Current Date Time: Monday 11 AM   --> Tuesday 11 AM (nex working day)
+     */
     private fun ZonedDateTime.nextWorkingDay() = this.with(TemporalsExtension.nextWorkingDay())
+
+    /**
+     * Provides next working day for current date-time or same day if current date-time is already working day.
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Monday 11 AM (nex working day - excluding weekends)
+     *  - Current Date Time: Sunday 11 AM   --> Monday 11 AM (nex working day - excluding weekends)
+     *  - Current Date Time: Monday 11 AM   --> Monday 11 AM (Same day - as it monday is working day)
+     */
     private fun ZonedDateTime.nextWorkingDayOrSame() = this.with(TemporalsExtension.nextWorkingDayOrSame())
+
+    /**
+     * Provides immediate start of working hour for working day, or same time if it's on weekend.
+     *
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Saturday 11 AM (Same - because on non-weekday)
+     *  - Current Date Time: Sunday 11 AM   --> Sunday 11 AM (Same - because on non-weekday)
+     *  - Current Date Time: Monday 11 AM   --> Monday 11 AM (Same - because it's already in working hour)
+     *  - Current Date Time: Tuesday 8 PM   --> Wednesday 9 AM (Next day, because it was after hours)
+     *  - Current Date Time: Tuesday 6 AM   --> Tuesday 9 AM (Same day but time changed to start of work)
+     */
     private fun ZonedDateTime.nextWorkingHourOrSame() = this.with(TemporalsExtension.nextWorkingHourOrSame())
+
     private fun ZonedDateTime.nextNonWorkingHour() = this.with(TemporalsExtension.nextNonWorkingHourOrSame())
 
-    /** Previous working start hour of the day.*/
+    /**
+     * Previous working start hour of the day irrespective of weekday or weekends.
+     *
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Saturday 9 AM
+     *  - Current Date Time: Sunday 2 PM    --> Sunday 9 AM
+     *  - Current Date Time: Monday 11 AM   --> Monday 9 AM
+     *  - Current Date Time: Tuesday 8 PM   --> Tuesday 5 PM (End of the day for same day)
+     *  - Current Date Time: Tuesday 6 AM   --> Monday 5 PM (End of the day for previous day)
+     */
     private fun ZonedDateTime.prevWorkingHour() = this.with(TemporalsExtension.prevWorkingHour())
 
     private fun ZonedDateTime.diffWith(endDateTime: ZonedDateTime): Duration {

--- a/src/main/kotlin/dev/hossain/time/TemporalsExtension.kt
+++ b/src/main/kotlin/dev/hossain/time/TemporalsExtension.kt
@@ -13,10 +13,14 @@ object TemporalsExtension {
     /**
      * Returns an adjuster that returns the next working day, ignoring Saturday and Sunday.
      *
-     *
      * Some territories have weekends that do not consist of Saturday and Sunday.
      * No implementation is supplied to support this, however an adjuster
      * can be easily written to do so.
+     *
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Monday 11 AM (nex working day - excluding weekends)
+     *  - Current Date Time: Sunday 11 AM   --> Monday 11 AM (nex working day - excluding weekends)
+     *  - Current Date Time: Monday 11 AM   --> Tuesday 11 AM (nex working day)
      *
      * @return the next working day adjuster, not null
      */
@@ -47,17 +51,39 @@ object TemporalsExtension {
 
     /**
      * Adjuster to provide next working hour on a working day.
+     *
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Saturday 11 AM (Same - because on non-weekday)
+     *  - Current Date Time: Sunday 11 AM   --> Sunday 11 AM (Same - because on non-weekday)
+     *  - Current Date Time: Monday 11 AM   --> Monday 11 AM (Same - because it's already in working hour)
+     *  - Current Date Time: Tuesday 8 PM   --> Wednesday 9 AM (Next day, because it was after hours)
+     *  - Current Date Time: Tuesday 6 AM   --> Tuesday 9 AM (Same day but time changed to start of work)
      */
     fun nextWorkingHourOrSame(): TemporalAdjuster {
         return Adjuster.NEXT_WORKING_HOUR_OR_SAME
     }
 
+    /**
+     * Previous working start hour of the day irrespective of weekday or weekends.
+     *
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Saturday 9 AM
+     *  - Current Date Time: Sunday 2 PM    --> Sunday 9 AM
+     *  - Current Date Time: Monday 11 AM   --> Monday 9 AM
+     *  - Current Date Time: Tuesday 8 PM   --> Tuesday 5 PM (End of the day for same day)
+     *  - Current Date Time: Tuesday 6 AM   --> Monday 5 PM (End of the day for previous day)
+     */
     fun prevWorkingHour(): TemporalAdjuster {
         return Adjuster.PREV_WORKING_HOUR
     }
 
     /**
      * Provides (approximate) time that indicates start of day at 12:00am of that day.
+     *
+     * Example:
+     *  - Current Date Time: Saturday 11 AM --> Saturday 12 AM (Reset to 12:00 am)
+     *  - Current Date Time: Sunday 11 AM   --> Sunday 12 AM (Reset to 12:00 am)
+     *  - Current Date Time: Monday 2 PM    --> Monday 12 AM (Reset to 12:00 am)
      */
     fun startOfDay(): TemporalAdjuster {
         return Adjuster.START_OF_DAY


### PR DESCRIPTION
Used following test code

```kotlin

    internal fun testExtensions() {
        val timeZoneId = ZoneId.of("America/New_York")
        val satday10am =
            Instant.parse("2022-09-03T10:00:00-04:00").toJavaInstant().atZone(timeZoneId) // 10:00am Saturday
        val sunday2pm =
            Instant.parse("2022-09-04T14:30:00-04:00").toJavaInstant().atZone(timeZoneId) // 10:00am Saturday
        val monday10am = Instant.parse("2022-09-05T10:00:00-04:00").toJavaInstant().atZone(timeZoneId) // 10:00am monday
        val tuesday6am = Instant.parse("2022-09-06T06:45:00-04:00").toJavaInstant().atZone(timeZoneId) // 08:00pm tuesday
        val tuesday8pm = Instant.parse("2022-09-06T20:45:00-04:00").toJavaInstant().atZone(timeZoneId) // 08:00pm tuesday

        println("\n>>>>>>>>> $satday10am <<<<<<<<<")
        println("> startOfDay = ${satday10am.startOfDay()}")
        println("> nextWorkingDay = ${satday10am.nextWorkingDay()}")
        println("> nextWorkingDayOrSame = ${satday10am.nextWorkingDayOrSame()}")
        println("> nextWorkingHourOrSame = ${satday10am.nextWorkingHourOrSame()}")
        println("> nextNonWorkingHour = ${satday10am.nextNonWorkingHour()}")
        println("> prevWorkingHour = ${satday10am.prevWorkingHour()}")

        println("\n>>>>>>>>> $sunday2pm <<<<<<<<<")
        println("> startOfDay = ${sunday2pm.startOfDay()}")
        println("> nextWorkingDay = ${sunday2pm.nextWorkingDay()}")
        println("> nextWorkingDayOrSame = ${sunday2pm.nextWorkingDayOrSame()}")
        println("> nextWorkingHourOrSame = ${sunday2pm.nextWorkingHourOrSame()}")
        println("> nextNonWorkingHour = ${sunday2pm.nextNonWorkingHour()}")
        println("> prevWorkingHour = ${sunday2pm.prevWorkingHour()}")

        println("\n>>>>>>>>> $monday10am <<<<<<<<<")
        println("> startOfDay = ${monday10am.startOfDay()}")
        println("> nextWorkingDay = ${monday10am.nextWorkingDay()}")
        println("> nextWorkingDayOrSame = ${monday10am.nextWorkingDayOrSame()}")
        println("> nextWorkingHourOrSame = ${monday10am.nextWorkingHourOrSame()}")
        println("> nextNonWorkingHour = ${monday10am.nextNonWorkingHour()}")
        println("> prevWorkingHour = ${monday10am.prevWorkingHour()}")

        println("\n>>>>>>>>> $tuesday6am <<<<<<<<<")
        println("> startOfDay = ${tuesday6am.startOfDay()}")
        println("> nextWorkingDay = ${tuesday6am.nextWorkingDay()}")
        println("> nextWorkingDayOrSame = ${tuesday6am.nextWorkingDayOrSame()}")
        println("> nextWorkingHourOrSame = ${tuesday6am.nextWorkingHourOrSame()}")
        println("> nextNonWorkingHour = ${tuesday6am.nextNonWorkingHour()}")
        println("> prevWorkingHour = ${tuesday6am.prevWorkingHour()}")

        println("\n>>>>>>>>> $tuesday8pm <<<<<<<<<")
        println("> startOfDay = ${tuesday8pm.startOfDay()}")
        println("> nextWorkingDay = ${tuesday8pm.nextWorkingDay()}")
        println("> nextWorkingDayOrSame = ${tuesday8pm.nextWorkingDayOrSame()}")
        println("> nextWorkingHourOrSame = ${tuesday8pm.nextWorkingHourOrSame()}")
        println("> nextNonWorkingHour = ${tuesday8pm.nextNonWorkingHour()}")
        println("> prevWorkingHour = ${tuesday8pm.prevWorkingHour()}")
    }
```