### PR TITLE
[ADDED] Unit test for the initial response time.

### DIFF
--- a/src/main/kotlin/dev/hossain/githubstats/repository/PullRequestStatsRepoImpl.kt
+++ b/src/main/kotlin/dev/hossain/githubstats/repository/PullRequestStatsRepoImpl.kt
@@ -46,6 +46,7 @@ class PullRequestStatsRepoImpl(
 
         if (!pullRequest.isMerged) {
             // Skips PR stats generation if PR is not merged at all.
+            Log.v("The PR#${pullRequest.number} is not merged. Skipping PR stat analysis.")
             return StatsResult.Failure(IllegalStateException("PR has not been merged, no reason to analyze PR stats."))
         }
 

--- a/src/main/kotlin/dev/hossain/githubstats/repository/PullRequestStatsRepoImpl.kt
+++ b/src/main/kotlin/dev/hossain/githubstats/repository/PullRequestStatsRepoImpl.kt
@@ -19,6 +19,7 @@ import dev.hossain.githubstats.service.GithubApiService
 import dev.hossain.githubstats.service.TimelineEventsPagerService
 import dev.hossain.time.DateTimeDiffer
 import dev.hossain.time.UserTimeZone
+import dev.hossain.time.print
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
 import org.jetbrains.annotations.TestOnly
@@ -197,6 +198,10 @@ class PullRequestStatsRepoImpl(
                 timeZoneId = userTimeZone.get(prReviewerUserId)
             )
             Log.i("  -- First Responded[${firstReviewedEvent.state.name.lowercase()}] in `$reviewTimeInWorkingHours` by `$prReviewerUserId`.")
+            Log.v(
+                "     -- 🔍👀 Initial response event: $firstReviewedEvent. PR available on ${prAvailableForReviewOn.print()} " +
+                    "and event on ${firstReviewedEvent.submitted_at.toInstant().print()}"
+            )
 
             initialResponseTime[prReviewerUserId] = reviewTimeInWorkingHours
         }

--- a/src/main/kotlin/dev/hossain/time/InstantExtension.kt
+++ b/src/main/kotlin/dev/hossain/time/InstantExtension.kt
@@ -8,8 +8,8 @@ import java.time.ZonedDateTime
  * Extension function to convert [Instant] to [ZonedDateTime] at fixed time zone.
  */
 fun Instant.toZdt(): ZonedDateTime {
-    val date1JavaInstant: java.time.Instant = this.toJavaInstant()
-    return date1JavaInstant.atZone(Zone.city("New York"))
+    val javaInstant: java.time.Instant = this.toJavaInstant()
+    return javaInstant.atZone(Zone.city("New York"))
 }
 
 /**

--- a/src/main/kotlin/dev/hossain/time/InstantExtension.kt
+++ b/src/main/kotlin/dev/hossain/time/InstantExtension.kt
@@ -1,0 +1,20 @@
+package dev.hossain.time
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
+import java.time.ZonedDateTime
+
+/**
+ * Extension function to convert [Instant] to [ZonedDateTime] at fixed time zone.
+ */
+fun Instant.toZdt(): ZonedDateTime {
+    val date1JavaInstant: java.time.Instant = this.toJavaInstant()
+    return date1JavaInstant.atZone(Zone.city("New York"))
+}
+
+/**
+ * Extension function to pretty print [Instant] for fixed time zone.
+ */
+fun Instant.print(): String {
+    return this.toZdt().format()
+}

--- a/src/test/kotlin/dev/hossain/time/DateTimeDifferTest.kt
+++ b/src/test/kotlin/dev/hossain/time/DateTimeDifferTest.kt
@@ -2,6 +2,7 @@ package dev.hossain.time
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -275,6 +276,17 @@ internal class DateTimeDifferTest {
         val diffWorkingHours = DateTimeDiffer.diffWorkingHours(startTime, endTime, zoneId)
 
         assertThat(diffWorkingHours).isEqualTo("80h".duration())
+    }
+
+    @Test
+    fun `diff - given start time is during weekend and ends in the middle of week after hours - provides diff of working hour only`() {
+        val startTime: Instant = "2022-09-17T22:28:41Z".toInstant() // Saturday, September 17, 2022 at 6:28:41 PM Eastern Daylight
+        val endTime: Instant = "2022-09-22T11:51:40Z".toInstant() // Thursday, September 22, 2022 at 7:51:40 AM Eastern Daylight Time
+
+        val diffWorkingHours = DateTimeDiffer.diffWorkingHours(startTime, endTime, zoneId)
+
+        assertThat(diffWorkingHours).isEqualTo("24h".duration()) // Indicates 8h x 3 = 24 hours for 3 working days
+        assertThat(diffWorkingHours).isEqualTo("1d".duration()) // This is same as 24 hours, which is 3 working days
     }
 
     private fun String.duration(): Duration = Duration.parse(this)

--- a/src/test/kotlin/dev/hossain/time/ZonedDateTimeExtensionTest.kt
+++ b/src/test/kotlin/dev/hossain/time/ZonedDateTimeExtensionTest.kt
@@ -2,7 +2,6 @@ package dev.hossain.time
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toJavaInstant
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 
@@ -120,10 +119,5 @@ internal class ZonedDateTimeExtensionTest {
     fun `isAfterWorkingHour - given date time before working hour - provides false`() {
         val dateTime = Instant.parse("2022-09-05T06:00:00-04:00").toZdt() // 06:00am Monday
         assertThat(dateTime.isAfterWorkingHour()).isFalse()
-    }
-
-    private fun Instant.toZdt(): ZonedDateTime {
-        val date1JavaInstant: java.time.Instant = this.toJavaInstant()
-        return date1JavaInstant.atZone(Zone.city("New York"))
     }
 }


### PR DESCRIPTION
Sample data for test

Part 1 for #51 

```
Nov. 21, 2022 9:56:55 P.M. org.junit.platform.launcher.core.EngineDiscoveryOrchestrator lambda$logTestDescriptorExclusionReasons$7
INFO: 0 containers and 15 tests were Method or class mismatch
PR: PullRequest(id=1059412392, number=47550, state=closed, title=feat(docs): update forum moderation section, url=https://api.github.com/repos/freeCodeCamp/freeCodeCamp/pulls/47550, html_url=https://github.com/freeCodeCamp/freeCodeCamp/pull/47550, user=User: hbar1st, merged=true, created_at=2022-09-17T22:28:41Z, updated_at=2022-09-22T22:08:33Z, closed_at=2022-09-22T22:08:33Z, merged_at=2022-09-22T22:08:33Z)

- Getting PR#123 info. Analyzing 58 events from the PR. (URL: https://github.com/freeCodeCamp/freeCodeCamp/pull/47550)
Using default America/New_York timezone for 'ShaunSHamilton'. Use UserTimeZone to configure time zone for 'ShaunSHamilton'.
  -- First Responded[change_requested] in `0s` by `ShaunSHamilton`.
     -- 🔍👀 Initial response event: Reviewed (change_requested) by `ShaunSHamilton` at https://github.com/freeCodeCamp/freeCodeCamp/pull/47550#pullrequestreview-1111527385. PR available on Saturday, September 17, 2022 at 6:28:41 PM Eastern Daylight Time and event on Sunday, September 18, 2022 at 7:28:03 AM Eastern Daylight Time 2022-09-18T11:28:03Z
Using default America/New_York timezone for 'SaintPeter'. Use UserTimeZone to configure time zone for 'SaintPeter'.
  -- First Responded[change_requested] in `2h 24m` by `SaintPeter`.
     -- 🔍👀 Initial response event: Reviewed (change_requested) by `SaintPeter` at https://github.com/freeCodeCamp/freeCodeCamp/pull/47550#pullrequestreview-1112449039. PR available on Saturday, September 17, 2022 at 6:28:41 PM Eastern Daylight Time and event on Monday, September 19, 2022 at 11:24:20 AM Eastern Daylight Time 2022-09-19T15:24:20Z
Using default America/New_York timezone for 'jeremylt'. Use UserTimeZone to configure time zone for 'jeremylt'.
  -- First Responded[commented] in `2h 49m` by `jeremylt`.
     -- 🔍👀 Initial response event: Reviewed (commented) by `jeremylt` at https://github.com/freeCodeCamp/freeCodeCamp/pull/47550#pullrequestreview-1112492011. PR available on Saturday, September 17, 2022 at 6:28:41 PM Eastern Daylight Time and event on Monday, September 19, 2022 at 11:49:11 AM Eastern Daylight Time 2022-09-19T15:49:11Z
Using default America/New_York timezone for 'naomi-lgbt'. Use UserTimeZone to configure time zone for 'naomi-lgbt'.
  -- First Responded[commented] in `8h` by `naomi-lgbt`.
     -- 🔍👀 Initial response event: Reviewed (commented) by `naomi-lgbt` at https://github.com/freeCodeCamp/freeCodeCamp/pull/47550#pullrequestreview-1113054980. PR available on Saturday, September 17, 2022 at 6:28:41 PM Eastern Daylight Time and event on Monday, September 19, 2022 at 10:26:48 PM Eastern Daylight Time 2022-09-20T02:26:48Z
Using default America/New_York timezone for 'Sboonny'. Use UserTimeZone to configure time zone for 'Sboonny'.
  -- First Responded[commented] in `1d` by `Sboonny`.
     -- 🔍👀 Initial response event: Reviewed (commented) by `Sboonny` at https://github.com/freeCodeCamp/freeCodeCamp/pull/47550#pullrequestreview-1116901558. PR available on Saturday, September 17, 2022 at 6:28:41 PM Eastern Daylight Time and event on Thursday, September 22, 2022 at 7:51:40 AM Eastern Daylight Time 2022-09-22T11:51:40Z
Using default America/New_York timezone for 'ShaunSHamilton'. Use UserTimeZone to configure time zone for 'ShaunSHamilton'.
  -- Reviewed and ✔approved in `14h` by `ShaunSHamilton`. PR open->merged: 4d 23h 39m 52s
Using default America/New_York timezone for 'naomi-lgbt'. Use UserTimeZone to configure time zone for 'naomi-lgbt'.
  -- Reviewed and ✔approved in `11h` by `naomi-lgbt`. PR open->merged: 4d 23h 39m 52s
```