### PR TITLE
[UPDATE] JDK and gradle version for github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,8 @@ jobs:
     - name: set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        # Use JDK LTS version (keep this in sync with other workflows)
+        java-version: '21'
         distribution: 'temurin'
         cache: gradle
 

--- a/.github/workflows/static-docs.yml
+++ b/.github/workflows/static-docs.yml
@@ -1,4 +1,5 @@
 # Simple workflow for deploying static content to GitHub Pages
+# Publishes dokka generated kotlin documentation to GitHub Pages
 name: Deploy static content to Pages
 
 on:
@@ -35,6 +36,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
+          # Use JDK LTS version (keep this in sync with other workflows)
           java-version: '21'
           distribution: 'temurin'
 
@@ -43,7 +45,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
         with:
-           gradle-version: '8.4'
+           # Match gradle/wrapper/gradle-wrapper.properties version
+           gradle-version: '8.12'
 
       - name: Build with Gradle
         run: gradle clean dokkaGeneratePublicationHtml


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to ensure consistency in the JDK and Gradle versions used across different workflows. The changes primarily focus on upgrading to the latest LTS versions and adding comments for clarity.

Updates to GitHub Actions workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L32-R33): Updated the JDK version to 21 (LTS) to keep it in sync with other workflows.
* [`.github/workflows/static-docs.yml`](diffhunk://#diff-ac13f40bac4559012ad0fba876c2b9e1c7478763924f22a915598f837ecff84eR2): Added a comment to clarify the purpose of the workflow, which is to publish Dokka-generated Kotlin documentation to GitHub Pages.
* [`.github/workflows/static-docs.yml`](diffhunk://#diff-ac13f40bac4559012ad0fba876c2b9e1c7478763924f22a915598f837ecff84eR39): Updated the JDK version to 21 (LTS) to keep it in sync with other workflows.
* [`.github/workflows/static-docs.yml`](diffhunk://#diff-ac13f40bac4559012ad0fba876c2b9e1c7478763924f22a915598f837ecff84eL46-R49): Updated the Gradle version to 8.12 to match the version specified in `gradle/wrapper/gradle-wrapper.properties`.