### PR TITLE
[REFACTOR] Converted user city to enum for compile time safety

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,7 @@
       <GradleProjectSettings>
         <option name="distributionType" value="WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="homebrew-23" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/src/main/kotlin/dev/hossain/time/UserCity.kt
+++ b/src/main/kotlin/dev/hossain/time/UserCity.kt
@@ -3,13 +3,16 @@ package dev.hossain.time
 /**
  * User cities for time zone defined in [UserTimeZone].
  */
-object UserCity {
-    const val ATLANTA = "Atlanta"
-    const val CHICAGO = "Chicago"
-    const val DETROIT = "Detroit"
-    const val NEW_YORK = "New York"
-    const val PHOENIX = "Phoenix"
-    const val SAN_FRANCISCO = "San Francisco"
-    const val TORONTO = "Toronto"
-    const val VANCOUVER = "Vancouver"
+enum class UserCity(
+    val cityName: String,
+) {
+    ATLANTA("Atlanta"),
+    CHICAGO("Chicago"),
+    DETROIT("Detroit"),
+    NEW_YORK("New York"),
+    PHOENIX("Phoenix"),
+    PARIS("Paris"),
+    SAN_FRANCISCO("San Francisco"),
+    TORONTO("Toronto"),
+    VANCOUVER("Vancouver"),
 }

--- a/src/main/kotlin/dev/hossain/time/Zone.kt
+++ b/src/main/kotlin/dev/hossain/time/Zone.kt
@@ -32,8 +32,8 @@ object Zone {
         )
 
     /**
-     * Provides [ZoneId] based on known [cityName] defined in [UserCity].
-     * @throws NullPointerException if [cityName] is not in [cities]
+     * Provides [ZoneId] based on known [userCity] defined in [UserCity].
+     * @throws NullPointerException if [userCity] is not in [cities]
      */
-    fun city(cityName: String): ZoneId = requireNotNull(cities[cityName]) { "Please add $cityName to Zone.cities map first." }
+    fun city(userCity: UserCity): ZoneId = requireNotNull(cities[userCity]) { "Please add ${userCity.cityName} to Zone.cities map first." }
 }

--- a/src/test/kotlin/dev/hossain/time/ZoneTest.kt
+++ b/src/test/kotlin/dev/hossain/time/ZoneTest.kt
@@ -1,0 +1,31 @@
+package dev.hossain.time
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+
+/**
+ * Contains unit tests for [Zone].
+ */
+class ZoneTest {
+    @Test
+    fun `city returns correct ZoneId for known UserCity`() {
+        assertThat(Zone.city(UserCity.ATLANTA)).isEqualTo(ZoneId.of("America/New_York"))
+        assertThat(Zone.city(UserCity.CHICAGO)).isEqualTo(ZoneId.of("America/Chicago"))
+        assertThat(Zone.city(UserCity.DETROIT)).isEqualTo(ZoneId.of("America/Detroit"))
+        assertThat(Zone.city(UserCity.NEW_YORK)).isEqualTo(ZoneId.of("America/New_York"))
+        assertThat(Zone.city(UserCity.PHOENIX)).isEqualTo(ZoneId.of("America/Phoenix"))
+        assertThat(Zone.city(UserCity.SAN_FRANCISCO)).isEqualTo(ZoneId.of("America/Los_Angeles"))
+        assertThat(Zone.city(UserCity.TORONTO)).isEqualTo(ZoneId.of("America/Toronto"))
+        assertThat(Zone.city(UserCity.VANCOUVER)).isEqualTo(ZoneId.of("America/Vancouver"))
+    }
+
+    @Test
+    fun `city throws NullPointerException for unknown UserCity`() {
+        // Create a fake UserCity not in the Zone.cities map
+
+        val exception = kotlin.runCatching { Zone.city(UserCity.PARIS) }.exceptionOrNull()
+        assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(exception?.message).contains("Paris")
+    }
+}


### PR DESCRIPTION
This pull request introduces several updates to improve the maintainability and functionality of the time zone management codebase. The most significant changes include refactoring `UserCity` from a static object to an `enum class`, updating the `Zone.city` method to use the `UserCity` enum, and adding unit tests for the `Zone` functionality.

### Refactoring and Enhancements:
* [`src/main/kotlin/dev/hossain/time/UserCity.kt`](diffhunk://#diff-6cf22d826ae9e4f6fd1c2ea9d7b238febe1f7b8edd849783e343bbbb0db3d161L6-R17): Refactored `UserCity` from a static object with constant strings to an `enum class`, which now includes a new city (`PARIS`). This change improves type safety and extensibility.
* [`src/main/kotlin/dev/hossain/time/Zone.kt`](diffhunk://#diff-79e75b36f538cbcd4c2b6a57df27650893e4f2356e2d9756b8ec5e5865f52693L35-R38): Updated the `Zone.city` method to accept a `UserCity` enum instead of a plain string, enhancing type safety and reducing potential runtime errors.

### Testing:
* [`src/test/kotlin/dev/hossain/time/ZoneTest.kt`](diffhunk://#diff-c86811c29c0f675cc23528140bd8d952a8d0dd1404364ff20cc25a83744956f4R1-R31): Added comprehensive unit tests for the `Zone.city` method to verify correct behavior for known `UserCity` values and ensure proper error handling for unknown cities.

### Configuration:
* [`.idea/gradle.xml`](diffhunk://#diff-952b752681ded498853ce6363aa309aac9e6bd15fe12a907be0b8d2142d1fa21L9-R9): Changed the Gradle JVM configuration to use the `JAVA_HOME` environment variable instead of a hardcoded value, improving portability across environments.