### PR TITLE
fix: Configure Gradle toolchain to fix build

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 
 rootProject.name = "github-stats"
-


### PR DESCRIPTION
The build was failing because a Java 17 toolchain was not found. This change configures Gradle to automatically download the required JDK by adding the foojay-resolver plugin, which provides toolchain repositories.