### PR TITLE
Fix cli

### DIFF
--- a/src/main/kotlin/dev/hossain/githubstats/client/GhCliApiClient.kt
+++ b/src/main/kotlin/dev/hossain/githubstats/client/GhCliApiClient.kt
@@ -390,12 +390,13 @@ class GhCliApiClient(
         endpoint: String,
         params: Map<String, String>,
     ): List<String> {
-        val endpointWithParams = if (params.isEmpty()) {
-            endpoint
-        } else {
-            val queryString = params.entries.joinToString("&") { "${it.key}=${it.value}" }
-            "$endpoint?$queryString"
-        }
+        val endpointWithParams =
+            if (params.isEmpty()) {
+                endpoint
+            } else {
+                val queryString = params.entries.joinToString("&") { "${it.key}=${it.value}" }
+                "$endpoint?$queryString"
+            }
 
         return listOf(GH_COMMAND, "api", endpointWithParams, "--method", "GET")
     }


### PR DESCRIPTION
This pull request updates the `GhCliApiClient` to improve how timeline events are deserialized from JSON and refines the way GET request parameters are handled. The most significant changes are the introduction of a polymorphic JSON adapter for timeline events and a more robust method for building API commands with query parameters.

### Timeline event deserialization improvements
* Configured a `PolymorphicJsonAdapterFactory` in the Moshi builder to support deserialization of multiple `TimelineEvent` subtypes, including `ClosedEvent`, `CommentedEvent`, `MergedEvent`, `ReadyForReviewEvent`, `ReviewRequestedEvent`, `ReviewedEvent`, and a fallback to `UnknownEvent` for unrecognized types. This makes handling timeline events more flexible and robust. [[1]](diffhunk://#diff-3f135c207632718ad7437c6d59ed8f3bd218c4283d68954cfd4f221fc5a11f33R5) [[2]](diffhunk://#diff-3f135c207632718ad7437c6d59ed8f3bd218c4283d68954cfd4f221fc5a11f33R14-R21) [[3]](diffhunk://#diff-3f135c207632718ad7437c6d59ed8f3bd218c4283d68954cfd4f221fc5a11f33L65-R85)

### API command building enhancements
* Updated the `buildGhApiCommand` method so that for GET requests, query parameters are now appended directly to the endpoint URL as a query string, rather than using repeated `-F` flags. This aligns with standard HTTP GET practices and simplifies command construction.